### PR TITLE
Add daemon termination support

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -212,8 +212,7 @@ func (d *Daemon) Close() error {
 func (d *Daemon) awaitTermination() {
 	go func() {
 		d.terminateWG.Wait()
-		d.Close()
-		os.Exit(0)
+		go d.KillOnTimeout(10 * time.Second)
 	}()
 }
 

--- a/daemon.go
+++ b/daemon.go
@@ -150,7 +150,7 @@ func (d *Daemon) Addrs() []ma.Multiaddr {
 	return d.host.Addrs()
 }
 
-func (d *Daemon) ListenAndServe() error {
+func (d *Daemon) Serve() error {
 	for {
 		if d.isClosed() {
 			return nil

--- a/daemon.go
+++ b/daemon.go
@@ -88,7 +88,6 @@ func NewDaemon(ctx context.Context, maddr ma.Multiaddr, dhtMode string, opts ...
 	}
 	d.listener = l
 
-	go d.listen()
 	go d.trapSignals()
 
 	return d, nil
@@ -151,10 +150,10 @@ func (d *Daemon) Addrs() []ma.Multiaddr {
 	return d.host.Addrs()
 }
 
-func (d *Daemon) listen() {
+func (d *Daemon) ListenAndServe() error {
 	for {
 		if d.isClosed() {
-			return
+			return nil
 		}
 
 		c, err := d.listener.Accept()
@@ -212,7 +211,8 @@ func (d *Daemon) Close() error {
 func (d *Daemon) awaitTermination() {
 	go func() {
 		d.terminateWG.Wait()
-		go d.KillOnTimeout(10 * time.Second)
+		time.Sleep(time.Second * 30)
+		d.Close()
 	}()
 }
 
@@ -225,6 +225,5 @@ func (d *Daemon) KillOnTimeout(timeout time.Duration) {
 		return
 	case <-time.NewTimer(timeout).C:
 		d.Close()
-		os.Exit(0)
 	}
 }

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -377,6 +377,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	done := make(chan struct{})
+	go func() {
+		d.ListenAndServe()
+		done <- struct{}{}
+	}()
+
 	if *idleTimeout > 0 {
 		go d.KillOnTimeout(*idleTimeout)
 	}
@@ -426,5 +432,5 @@ func main() {
 		go func() { log.Println(http.ListenAndServe(c.MetricsAddress, nil)) }()
 	}
 
-	select {}
+	<-done
 }

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -378,7 +378,7 @@ func main() {
 	}
 
 	if *idleTimeout > 0 {
-		go d.KillOnTimeout(*idleTimeout)
+		d.KillOnTimeout(*idleTimeout)
 	}
 
 	if c.PubSub.Enabled {
@@ -426,5 +426,7 @@ func main() {
 		go func() { log.Println(http.ListenAndServe(c.MetricsAddress, nil)) }()
 	}
 
-	d.Serve()
+	if err := d.Serve(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -379,7 +379,7 @@ func main() {
 
 	done := make(chan struct{})
 	go func() {
-		d.ListenAndServe()
+		d.Serve()
 		done <- struct{}{}
 	}()
 

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -103,6 +103,7 @@ func main() {
 	useTls := flag.Bool("tls", true, "Enables TLS1.3 channel security protocol")
 	forceReachabilityPublic := flag.Bool("forceReachabilityPublic", false, "Set up ForceReachability as public for autonat")
 	forceReachabilityPrivate := flag.Bool("forceReachabilityPrivate", false, "Set up ForceReachability as private for autonat")
+	idleTimeout := flag.Duration("idleTimeout", 0, "if this flag has as positive value the daemon will kill itself if no persistent conncetions are open in the given time interval")
 
 	flag.Parse()
 
@@ -374,6 +375,10 @@ func main() {
 	d, err := p2pd.NewDaemon(context.Background(), &c.ListenAddr, c.DHT.Mode, opts...)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if *idleTimeout > 0 {
+		go d.KillOnTimeout(*idleTimeout)
 	}
 
 	if c.PubSub.Enabled {

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -377,12 +377,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	done := make(chan struct{})
-	go func() {
-		d.Serve()
-		done <- struct{}{}
-	}()
-
 	if *idleTimeout > 0 {
 		go d.KillOnTimeout(*idleTimeout)
 	}
@@ -432,5 +426,5 @@ func main() {
 		go func() { log.Println(http.ListenAndServe(c.MetricsAddress, nil)) }()
 	}
 
-	<-done
+	d.Serve()
 }

--- a/persistent_stream.go
+++ b/persistent_stream.go
@@ -29,14 +29,14 @@ func (d *Daemon) handleUpgradedConn(r ggio.Reader, unsafeW ggio.Writer) {
 		}
 	}()
 
-	if d.cancelTerminate != nil {
-		d.cancelTerminate()
+	if d.cancelTerminateTimer != nil {
+		d.cancelTerminateTimer()
 	}
 
 	d.terminateWG.Add(1)
 	defer d.terminateWG.Done()
 
-	d.terminateOnce.Do(d.awaitTermination)
+	d.terminateOnce.Do(func() { go d.awaitTermination() })
 
 	w := &safeWriter{w: unsafeW}
 	for {

--- a/test/unary_handler_test.go
+++ b/test/unary_handler_test.go
@@ -79,37 +79,6 @@ func TestUnaryCalls(t *testing.T) {
 	)
 }
 
-func TestCancellation(t *testing.T) {
-	_, p1, cancel1 := createDaemonClientPair(t)
-	_, p2, cancel2 := createDaemonClientPair(t)
-
-	t.Cleanup(func() {
-		cancel1()
-		cancel2()
-	})
-
-	peer1ID, peer1Addrs, err := p1.Identify()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := p2.Connect(peer1ID, peer1Addrs); err != nil {
-		t.Fatal(err)
-	}
-
-	var proto protocol.ID = "sqrt"
-	if err := p1.AddUnaryHandler(proto, sqrtHandler); err != nil {
-		t.Fatal(err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	_, err = p2.CallUnaryHandler(ctx, peer1ID, proto, []byte("hi"))
-	if err == nil {
-		t.Fatal("expected error")
-	}
-}
-
 func TestAddUnaryHandler(t *testing.T) {
 	// create a singe daemon and connect two client to it
 	dmaddr, c1maddr, dir1Closer := getEndpointsMaker(t)(t)

--- a/test/unary_handler_test.go
+++ b/test/unary_handler_test.go
@@ -79,6 +79,37 @@ func TestUnaryCalls(t *testing.T) {
 	)
 }
 
+func TestCancellation(t *testing.T) {
+	_, p1, cancel1 := createDaemonClientPair(t)
+	_, p2, cancel2 := createDaemonClientPair(t)
+
+	t.Cleanup(func() {
+		cancel1()
+		cancel2()
+	})
+
+	peer1ID, peer1Addrs, err := p1.Identify()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p2.Connect(peer1ID, peer1Addrs); err != nil {
+		t.Fatal(err)
+	}
+
+	var proto protocol.ID = "sqrt"
+	if err := p1.AddUnaryHandler(proto, sqrtHandler); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err = p2.CallUnaryHandler(ctx, peer1ID, proto, []byte("hi"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestAddUnaryHandler(t *testing.T) {
 	// create a singe daemon and connect two client to it
 	dmaddr, c1maddr, dir1Closer := getEndpointsMaker(t)(t)

--- a/test/utils.go
+++ b/test/utils.go
@@ -45,6 +45,9 @@ func createDaemon(t *testing.T, daemonAddr ma.Multiaddr) (*p2pd.Daemon, func()) 
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	go daemon.ListenAndServe()
+
 	return daemon, cancelCtx
 }
 

--- a/test/utils.go
+++ b/test/utils.go
@@ -46,7 +46,7 @@ func createDaemon(t *testing.T, daemonAddr ma.Multiaddr) (*p2pd.Daemon, func()) 
 		t.Fatal(err)
 	}
 
-	go daemon.ListenAndServe()
+	go daemon.Serve()
 
 	return daemon, cancelCtx
 }


### PR DESCRIPTION
Currently, there are situations in which the daemon's clients fail to send a SIGTERM, which leads to dangling p2pd instances. This PR fixes this issue by killing the daemon as soon as the persistent connection counter hits zero (but only if at least one has been open). The PR also adds an `idleTimeout` flag. If the timeout's been reached and no persistent connections have been opened, the daemon terminates itself.