### PR TITLE
Fix deadlock in p2pclient/unary_handlers.go

### DIFF
--- a/p2pclient/unary_handlers.go
+++ b/p2pclient/unary_handlers.go
@@ -57,7 +57,6 @@ func (c *Client) run(r ggio.Reader, w ggio.Writer) {
 		case *pb.PersistentConnectionResponse_RequestHandling:
 			proto := protocol.ID(*resp.GetRequestHandling().Proto)
 
-			c.mhandlers.Lock()
 			h, found := c.unaryHandlers.Load(proto)
 			handler, ok := h.(UnaryHandlerFunc)
 			if !ok {
@@ -68,7 +67,6 @@ func (c *Client) run(r ggio.Reader, w ggio.Writer) {
 			if !found {
 				w.WriteMsg(makeErrProtoNotFoundMsg(resp.CallId, string(proto)))
 			}
-			c.mhandlers.Unlock()
 
 			go func() {
 				ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
In case of `!ok` and the following `return`, `c.mhandlers` won't be released, and this will lead to a deadlock.

One solution is to use `defer c.mhandlers.Unlock()`, however `c.mhandlers` does not seem to be useful here at all.