### PR TITLE
Update persistent connection protocol

### DIFF
--- a/p2pclient/unary_handlers.go
+++ b/p2pclient/unary_handlers.go
@@ -97,6 +97,16 @@ func (c *Client) getPersistentWriter() ggio.WriteCloser {
 			c.persistentConnWriter = w
 
 			r := ggio.NewDelimitedReader(conn, network.MessageSizeMax)
+
+			var msg pb.Response
+			if err := r.ReadMsg(&msg); err != nil {
+				panic(err)
+			}
+
+			if *msg.Type != pb.Response_OK {
+				panic("failed to open persistent connection")
+			}
+
 			go c.run(r, c.persistentConnWriter)
 
 		},

--- a/persistent_stream.go
+++ b/persistent_stream.go
@@ -279,6 +279,7 @@ func (d *Daemon) getPersistentStreamHandler(cw ggio.Writer) network.StreamHandle
 func (d *Daemon) sendReponseToRemote(req *pb.PersistentConnectionRequest) {
 	callID, err := uuid.FromBytes(req.CallId)
 	if err != nil {
+		log.Debugf("failed to unmarshal call id from bytes: %v\n", err)
 		return
 	}
 

--- a/persistent_stream.go
+++ b/persistent_stream.go
@@ -279,13 +279,13 @@ func (d *Daemon) getPersistentStreamHandler(cw ggio.Writer) network.StreamHandle
 func (d *Daemon) sendReponseToRemote(req *pb.PersistentConnectionRequest) {
 	callID, err := uuid.FromBytes(req.CallId)
 	if err != nil {
-		log.Debugf("failed to unmarshal call id from bytes: %v\n", err)
+		log.Debugf("failed to unmarshal call id from bytes: %v", err)
 		return
 	}
 
 	rc, found := d.responseWaiters.Load(callID)
 	if !found {
-		log.Debugf("could not find request awaiting response for following call id: %s\n", callID.String())
+		log.Debugf("could not find request awaiting response for following call id: %s", callID.String())
 		return
 	}
 

--- a/persistent_stream.go
+++ b/persistent_stream.go
@@ -284,6 +284,7 @@ func (d *Daemon) sendReponseToRemote(req *pb.PersistentConnectionRequest) {
 
 	rc, found := d.responseWaiters.Load(callID)
 	if !found {
+		log.Debugf("could not find request awaiting response for following call id: %s\n", callID.String())
 		return
 	}
 

--- a/persistent_stream.go
+++ b/persistent_stream.go
@@ -38,6 +38,12 @@ func (d *Daemon) handlePersistentConn(r ggio.Reader, unsafeW ggio.WriteCloser) {
 	d.terminateOnce.Do(func() { go d.awaitTermination() })
 
 	w := utils.NewSafeWriter(unsafeW)
+
+	if err := w.WriteMsg(&pb.Response{Type: pb.Response_OK.Enum()}); err != nil {
+		log.Debugw("error writing message", "error", err)
+		return
+	}
+
 	for {
 		var req pb.PersistentConnectionRequest
 		if err := r.ReadMsg(&req); err != nil {
@@ -89,11 +95,7 @@ func (d *Daemon) handlePersistentConnRequest(req pb.PersistentConnectionRequest,
 		}
 
 	case *pb.PersistentConnectionRequest_UnaryResponse:
-		resp := d.sendReponseToRemote(&req)
-		if err := w.WriteMsg(resp); err != nil {
-			log.Debugw("error reading message", "error", err)
-			return
-		}
+		d.sendReponseToRemote(&req)
 
 	case *pb.PersistentConnectionRequest_Cancel:
 		cf, found := d.cancelUnary.Load(callID)
@@ -274,26 +276,18 @@ func (d *Daemon) getPersistentStreamHandler(cw ggio.Writer) network.StreamHandle
 	}
 }
 
-func (d *Daemon) sendReponseToRemote(req *pb.PersistentConnectionRequest) *pb.PersistentConnectionResponse {
+func (d *Daemon) sendReponseToRemote(req *pb.PersistentConnectionRequest) {
 	callID, err := uuid.FromBytes(req.CallId)
 	if err != nil {
-		return errorUnaryCallString(
-			callID,
-			"malformed request: call id not in UUID format",
-		)
+		return
 	}
 
 	rc, found := d.responseWaiters.Load(callID)
 	if !found {
-		return errorUnaryCallString(
-			callID,
-			fmt.Sprintf("Response for call id %d not requested or cancelled", callID),
-		)
+		return
 	}
 
 	rc.(chan *pb.PersistentConnectionRequest) <- req
-
-	return okUnaryCallResponse(callID)
 }
 
 func errorUnaryCall(callID uuid.UUID, err error) *pb.PersistentConnectionResponse {


### PR DESCRIPTION
This PR adresses [this suggestion](https://github.com/learning-at-home/hivemind/pull/328#pullrequestreview-735367980). It implements the following:
1. The daemon now sends the client a status message on persistent connection craetion.
2. `sendResponseToRemote` no longer writes a status message to the client.