### PR TITLE
Parametrize persistent connection message size

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -21,7 +21,7 @@ const DefaultTimeout = 60 * time.Second
 func (d *Daemon) handleConn(c net.Conn) {
 	defer c.Close()
 
-	r := ggio.NewDelimitedReader(c, network.MessageSizeMax)
+	r := ggio.NewDelimitedReader(c, d.persistentConnMsgMaxSize)
 	w := ggio.NewDelimitedWriter(c)
 
 	for {

--- a/daemon.go
+++ b/daemon.go
@@ -55,13 +55,22 @@ type Daemon struct {
 	terminateOnce        sync.Once
 	terminateWG          sync.WaitGroup
 	cancelTerminateTimer context.CancelFunc
+
+	persistentConnMsgMaxSize int
 }
 
-func NewDaemon(ctx context.Context, maddr ma.Multiaddr, dhtMode string, opts ...libp2p.Option) (*Daemon, error) {
+func NewDaemon(
+	ctx context.Context,
+	maddr ma.Multiaddr,
+	dhtMode string,
+	persistentConnMsgMaxSize int,
+	opts ...libp2p.Option,
+) (*Daemon, error) {
 	d := &Daemon{
 		ctx:                      ctx,
 		handlers:                 make(map[protocol.ID]ma.Multiaddr),
 		registeredUnaryProtocols: make(map[protocol.ID]bool),
+		persistentConnMsgMaxSize: persistentConnMsgMaxSize,
 	}
 
 	if dhtMode != "" {

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -106,6 +106,8 @@ func main() {
 	idleTimeout := flag.Duration("idleTimeout", 0,
 		"Kills the daemon if no client opens a persistent connection in idleTimeout seconds."+
 			" The zero value (default) disables this feature")
+	persistentConnMaxMsgSize := flag.Int("persistentConnMaxMsgSize", 1<<22,
+		"Max size for persistent connection messages (bytes)")
 
 	flag.Parse()
 
@@ -374,7 +376,7 @@ func main() {
 	}
 
 	// start daemon
-	d, err := p2pd.NewDaemon(context.Background(), &c.ListenAddr, c.DHT.Mode, opts...)
+	d, err := p2pd.NewDaemon(context.Background(), &c.ListenAddr, c.DHT.Mode, *persistentConnMaxMsgSize, opts...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -106,7 +106,7 @@ func main() {
 	idleTimeout := flag.Duration("idleTimeout", 0,
 		"Kills the daemon if no client opens a persistent connection in idleTimeout seconds."+
 			" The zero value (default) disables this feature")
-	persistentConnMaxMsgSize := flag.Int("persistentConnMaxMsgSize", 4 * 1024 * 1024,
+	persistentConnMaxMsgSize := flag.Int("persistentConnMaxMsgSize", 4*1024*1024,
 		"Max size for persistent connection messages (bytes). Default: 4 MiB")
 
 	flag.Parse()

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -106,7 +106,7 @@ func main() {
 	idleTimeout := flag.Duration("idleTimeout", 0,
 		"Kills the daemon if no client opens a persistent connection in idleTimeout seconds."+
 			" The zero value (default) disables this feature")
-	persistentConnMaxMsgSize := flag.Int("persistentConnMaxMsgSize", 1<<22,
+	persistentConnMaxMsgSize := flag.Int("persistentConnMaxMsgSize", 4 * 1024 * 1024,
 		"Max size for persistent connection messages (bytes). Default: 4 MiB")
 
 	flag.Parse()

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -107,7 +107,7 @@ func main() {
 		"Kills the daemon if no client opens a persistent connection in idleTimeout seconds."+
 			" The zero value (default) disables this feature")
 	persistentConnMaxMsgSize := flag.Int("persistentConnMaxMsgSize", 1<<22,
-		"Max size for persistent connection messages (bytes)")
+		"Max size for persistent connection messages (bytes). Default: 4 MiB")
 
 	flag.Parse()
 

--- a/test/utils.go
+++ b/test/utils.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/test"
 
@@ -40,7 +41,7 @@ func createTempDir(t *testing.T) (string, string, func()) {
 
 func createDaemon(t *testing.T, daemonAddr ma.Multiaddr) (*p2pd.Daemon, func()) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
-	daemon, err := p2pd.NewDaemon(ctx, daemonAddr, "")
+	daemon, err := p2pd.NewDaemon(ctx, daemonAddr, "", network.MessageSizeMax)
 	daemon.EnablePubsub("gossipsub", false, false)
 	if err != nil {
 		t.Fatal(err)

--- a/trap_nonposix.go
+++ b/trap_nonposix.go
@@ -1,3 +1,4 @@
+//go:build windows || plan9 || nacl || js
 // +build windows plan9 nacl js
 
 package p2pd

--- a/trap_posix.go
+++ b/trap_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !plan9 && !nacl && !js
 // +build !windows,!plan9,!nacl,!js
 
 package p2pd


### PR DESCRIPTION
This PR adds a console argument for the maximum persistent connection message size.

