### PR TITLE
Fix broken QUIC option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,7 +93,6 @@ type Config struct {
 	Bootstrap         Bootstrap
 	DHT               DHT
 	ConnectionManager ConnectionManager
-	QUIC              bool
 	NatPortMap        bool
 	PubSub            PubSub
 	Relay             Relay
@@ -153,7 +152,6 @@ func NewDefaultConfig() Config {
 			HighWaterMark: 512,
 			GracePeriod:   120 * time.Second,
 		},
-		QUIC:       true,
 		NatPortMap: false,
 		PubSub: PubSub{
 			Enabled:    false,

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
 	github.com/libp2p/go-libp2p-noise v0.3.0
 	github.com/libp2p/go-libp2p-pubsub v0.6.0
-	github.com/libp2p/go-libp2p-quic-transport v0.15.2
 	github.com/libp2p/go-libp2p-tls v0.3.1
 	github.com/miekg/dns v1.1.45 // indirect
 	github.com/multiformats/go-base32 v0.0.4 // indirect

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -21,7 +21,6 @@ import (
 	config "github.com/libp2p/go-libp2p-daemon/config"
 	noise "github.com/libp2p/go-libp2p-noise"
 	ps "github.com/libp2p/go-libp2p-pubsub"
-	quic "github.com/libp2p/go-libp2p-quic-transport"
 	tls "github.com/libp2p/go-libp2p-tls"
 	multiaddr "github.com/multiformats/go-multiaddr"
 	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
@@ -74,7 +73,7 @@ func main() {
 	connMgrLo := flag.Int("connLo", 256, "Connection Manager Low Water mark")
 	connMgrHi := flag.Int("connHi", 512, "Connection Manager High Water mark")
 	connMgrGrace := flag.Duration("connGrace", 120*time.Second, "Connection Manager grace period (in seconds)")
-	QUIC := flag.Bool("quic", true, "Enables the QUIC transport")
+	flag.Bool("quic", true, "Enables the QUIC transport (deprecated, always enabled now)")
 	natPortMap := flag.Bool("natPortMap", false, "Enables NAT port mapping")
 	pubsub := flag.Bool("pubsub", false, "Enables pubsub")
 	pubsubRouter := flag.String("pubsubRouter", "gossipsub", "Specifies the pubsub router implementation")
@@ -176,10 +175,6 @@ func main() {
 		c.ConnectionManager.GracePeriod = *connMgrGrace
 		c.ConnectionManager.HighWaterMark = *connMgrHi
 		c.ConnectionManager.LowWaterMark = *connMgrLo
-	}
-
-	if QUIC != nil {
-		c.QUIC = *QUIC
 	}
 
 	if *natPortMap {
@@ -302,16 +297,6 @@ func main() {
 			log.Fatal(err)
 		}
 		opts = append(opts, libp2p.ConnectionManager(cm))
-	}
-
-	if c.QUIC {
-		opts = append(opts,
-			libp2p.DefaultTransports,
-			libp2p.Transport(quic.NewTransport),
-		)
-		if len(c.HostAddresses) == 0 {
-			log.Fatal("if we explicitly specify a transport, we must also explicitly specify the listen addrs")
-		}
 	}
 
 	if c.NatPortMap {


### PR DESCRIPTION
After #16, the daemon didn't work unless `-quic=0` is specified. Surprisingly, QUIC also worked in the latter case since it's now one of the libp2p default transports.

This PR deprecates the `-quic` option, so now it has no effect (QUIC is now enabled regardless of the option's value). The option is kept for backward compatibility. A user still can control whether peers use QUIC by adding/removing the `/ip4/.../udp/.../quic` addresses to/from `-hostAddrs`.

**Future work:**

- [x] Make a daemon release
- [x] Switch `hivemind` to that release
- [x] Deprecate `hivemind.P2P` options that don't have effect anymore