### PR TITLE
Fix idle timeout

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -225,10 +225,9 @@ func (d *Daemon) awaitTermination() {
 }
 
 func (d *Daemon) KillOnTimeout(timeout time.Duration) {
+	var ctx context.Context
+	ctx, d.cancelTerminateTimer = context.WithCancel(d.ctx)
 	go func() {
-		ctx, cancel := context.WithCancel(d.ctx)
-		d.cancelTerminateTimer = cancel
-
 		select {
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
Currently, the daemon is sometimes killed by the idle timeout even when the persistent connection is already open. This may be due to the `cancelTerminateTimer` field being non-volatile. This PR attempts to fix this by creating the field before starting children goroutines using the field.