### PR TITLE
Configure relay limits

### DIFF
--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -91,7 +91,7 @@ func main() {
 	trustedRelaysRaw := flag.String("trustedRelays", "", "comma separated list of multiaddrs for static circuit relay peers; by default, use bootstrap peers as trusted relays")
 	relayService := flag.Bool("relayService", true, "Configures this node to serve as a relay for others if -relayEnabled=1")
 	relayMaxCircuits := flag.Int("relayMaxCircuits", 16, "maximum number of open relay connections for each peer if -relayService=1")
-	relayMaxReservations := flag.Int("relayMaxReservations", 256, "maximum number of reserved relay slots for each peer if -relayService=1")
+	relayMaxReservations := flag.Int("relayMaxReservations", 128, "maximum number of reserved relay slots for each peer if -relayService=1")
 	relayBufferSize := flag.Int("relayBufferSize", 1 << 24, "Sets the hop limit for hop relays (deprecated, has no effect)")
 	relayDataLimit := flag.Int("relayDataLimit", 1 << 32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
 	relayTimeLimit := flag.Duration("relayTimeLimit", 30 * time.Minute, "maximum duration of a single active relayed connection if -relayService=1")
@@ -338,7 +338,7 @@ func main() {
 		opts = append(opts, libp2p.EnableRelay())
 
 		if *relayService {
-			opts = p2pd.ConfigureRelayService(opts)
+			opts = p2pd.ConfigureRelayService(opts, *relayMaxCircuits, *relayMaxReservations, *relayBufferSize, *relayDataLimit, *relayTimeLimit)
 		}
 	}
 

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -92,11 +92,11 @@ func main() {
 	relayService := flag.Bool("relayService", true, "Configures this node to serve as a relay for others if -relayEnabled=1")
 	relayMaxCircuits := flag.Int("relayMaxCircuits", 16, "maximum number of open relay connections for each peer if -relayService=1")
 	relayMaxReservations := flag.Int("relayMaxReservations", 128, "maximum number of reserved relay slots for each peer if -relayService=1")
-	relayBufferSize := flag.Int("relayBufferSize", 1 << 24, "size (in bytes) of the relayed connection buffers if -relayService=1")
-	relayDataLimit := flag.Int64("relayDataLimit", 1 << 32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
-	relayTimeLimit := flag.Duration("relayTimeLimit", 30 * time.Minute, "maximum duration of a single active relayed connection if -relayService=1")
+	relayBufferSize := flag.Int("relayBufferSize", 1<<24, "size (in bytes) of the relayed connection buffers if -relayService=1")
+	relayDataLimit := flag.Int64("relayDataLimit", 1<<32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
+	relayTimeLimit := flag.Duration("relayTimeLimit", 30*time.Minute, "maximum duration of a single active relayed connection if -relayService=1")
 
-    autonat := flag.Bool("autonat", false, "Enables the AutoNAT service")
+	autonat := flag.Bool("autonat", false, "Enables the AutoNAT service")
 	hostAddrs := flag.String("hostAddrs", "", "comma separated list of multiaddrs the host should listen on")
 	announceAddrs := flag.String("announceAddrs", "", "comma separated list of multiaddrs the host should announce to the network")
 	noListen := flag.Bool("noListenAddrs", false, "sets the host to listen on no addresses")
@@ -329,7 +329,7 @@ func main() {
 
 	if c.AutoNat {
 		opts = append(opts, libp2p.EnableNATService())
-        opts = append(opts, libp2p.EnableHolePunching())
+		opts = append(opts, libp2p.EnableHolePunching())
 	}
 
 	if c.Relay.Enabled {

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -92,7 +92,7 @@ func main() {
 	relayService := flag.Bool("relayService", true, "Configures this node to serve as a relay for others if -relayEnabled=1")
 	relayMaxCircuits := flag.Int("relayMaxCircuits", 16, "maximum number of open relay connections for each peer if -relayService=1")
 	relayMaxReservations := flag.Int("relayMaxReservations", 128, "maximum number of reserved relay slots for each peer if -relayService=1")
-	relayBufferSize := flag.Int("relayBufferSize", 1 << 24, "Sets the hop limit for hop relays (deprecated, has no effect)")
+	relayBufferSize := flag.Int("relayBufferSize", 1 << 24, "size (in bytes) of the relayed connection buffers if -relayService=1")
 	relayDataLimit := flag.Int64("relayDataLimit", 1 << 32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
 	relayTimeLimit := flag.Duration("relayTimeLimit", 30 * time.Minute, "maximum duration of a single active relayed connection if -relayService=1")
 

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -81,15 +81,22 @@ func main() {
 	pubsubSignStrict := flag.Bool("pubsubSignStrict", true, "Enables or disables pubsub strict signature verification")
 	gossipsubHeartbeatInterval := flag.Duration("gossipsubHeartbeatInterval", 0, "Specifies the gossipsub heartbeat interval")
 	gossipsubHeartbeatInitialDelay := flag.Duration("gossipsubHeartbeatInitialDelay", 0, "Specifies the gossipsub initial heartbeat delay")
+
 	relayEnabled := flag.Bool("relay", true, "Enables circuit relay")
 	flag.Bool("relayActive", false, "Enables active mode for relay (deprecated, has no effect, use -relayService=1 instead)")
 	flag.Bool("relayHop", false, "Enables hop for relay (deprecated, has no effect)")
 	relayHopLimit := flag.Int("relayHopLimit", 0, "Sets the hop limit for hop relays (deprecated, has no effect)")
-	relayService := flag.Bool("relayService", true, "Configures this node to serve as a relay for others if -relayEnabled=1")
 	autoRelay := flag.Bool("autoRelay", false, "Enables autorelay")
 	relayDiscovery := flag.Bool("relayDiscovery", true, "Discover potential relays in background if -autoRelay=1")
 	trustedRelaysRaw := flag.String("trustedRelays", "", "comma separated list of multiaddrs for static circuit relay peers; by default, use bootstrap peers as trusted relays")
-	autonat := flag.Bool("autonat", false, "Enables the AutoNAT service")
+	relayService := flag.Bool("relayService", true, "Configures this node to serve as a relay for others if -relayEnabled=1")
+	relayMaxCircuits := flag.Int("relayMaxCircuits", 16, "maximum number of open relay connections for each peer if -relayService=1")
+	relayMaxReservations := flag.Int("relayMaxReservations", 256, "maximum number of reserved relay slots for each peer if -relayService=1")
+	relayBufferSize := flag.Int("relayBufferSize", 1 << 24, "Sets the hop limit for hop relays (deprecated, has no effect)")
+	relayDataLimit := flag.Int("relayDataLimit", 1 << 32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
+	relayTimeLimit := flag.Duration("relayTimeLimit", 30 * time.Minute, "maximum duration of a single active relayed connection if -relayService=1")
+
+    autonat := flag.Bool("autonat", false, "Enables the AutoNAT service")
 	hostAddrs := flag.String("hostAddrs", "", "comma separated list of multiaddrs the host should listen on")
 	announceAddrs := flag.String("announceAddrs", "", "comma separated list of multiaddrs the host should announce to the network")
 	noListen := flag.Bool("noListenAddrs", false, "sets the host to listen on no addresses")
@@ -331,7 +338,7 @@ func main() {
 		opts = append(opts, libp2p.EnableRelay())
 
 		if *relayService {
-			opts = append(opts, libp2p.EnableRelayService())
+			opts = p2pd.ConfigureRelayService(opts)
 		}
 	}
 

--- a/p2pd/main.go
+++ b/p2pd/main.go
@@ -93,7 +93,7 @@ func main() {
 	relayMaxCircuits := flag.Int("relayMaxCircuits", 16, "maximum number of open relay connections for each peer if -relayService=1")
 	relayMaxReservations := flag.Int("relayMaxReservations", 128, "maximum number of reserved relay slots for each peer if -relayService=1")
 	relayBufferSize := flag.Int("relayBufferSize", 1 << 24, "Sets the hop limit for hop relays (deprecated, has no effect)")
-	relayDataLimit := flag.Int("relayDataLimit", 1 << 32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
+	relayDataLimit := flag.Int64("relayDataLimit", 1 << 32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
 	relayTimeLimit := flag.Duration("relayTimeLimit", 30 * time.Minute, "maximum duration of a single active relayed connection if -relayService=1")
 
     autonat := flag.Bool("autonat", false, "Enables the AutoNAT service")
@@ -329,9 +329,7 @@ func main() {
 
 	if c.AutoNat {
 		opts = append(opts, libp2p.EnableNATService())
-		if c.Relay.Enabled {
-			opts = append(opts, libp2p.EnableHolePunching())
-		}
+        opts = append(opts, libp2p.EnableHolePunching())
 	}
 
 	if c.Relay.Enabled {

--- a/relay.go
+++ b/relay.go
@@ -4,6 +4,7 @@ package p2pd
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
+	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 
 	"github.com/cenkalti/backoff/v4"
 )
@@ -146,4 +148,20 @@ func BeginRelayDiscovery(h host.Host, dht *dht.IpfsDHT, trustedRelays []string, 
 	}()
 
 	return cancel
+}
+
+func ConfigureRelayService(opts []libp2p.Option, maxCircuits: int, maxReservations: int, relayBufferSize: int,
+                           timeLimit: time.Duration, dataLimit: int) []libp2p.Option {
+    resources := relay.DefaultResources()
+    resources.Limit = &relay.RelayLimit{Duration: timeLimit, Data: dataLimit}
+    resources.MaxCircuits = maxCircuits
+    resources.MaxReservations = maxReservations
+    resources.MaxReservationsPerPeer = maxReservations
+    resources.MaxReservationsPerIP = maxReservations
+    resources.MaxReservationsPerASN = maxReservations
+    resources.BufferSize = relayBufferSize
+    opts = append(opts, libp2p.EnableRelayService(
+        relay.WithResources(resources)
+    ))
+    return opts
 }

--- a/relay.go
+++ b/relay.go
@@ -4,7 +4,6 @@ package p2pd
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -150,8 +149,7 @@ func BeginRelayDiscovery(h host.Host, dht *dht.IpfsDHT, trustedRelays []string, 
 	return cancel
 }
 
-func ConfigureRelayService(opts []libp2p.Option, maxCircuits: int, maxReservations: int, relayBufferSize: int,
-                           timeLimit: time.Duration, dataLimit: int) []libp2p.Option {
+func ConfigureRelayService(opts []libp2p.Option, maxCircuits int, maxReservations int, relayBufferSize int, timeLimit time.Duration, dataLimit int64) []libp2p.Option {
     resources := relay.DefaultResources()
     resources.Limit = &relay.RelayLimit{Duration: timeLimit, Data: dataLimit}
     resources.MaxCircuits = maxCircuits
@@ -161,7 +159,7 @@ func ConfigureRelayService(opts []libp2p.Option, maxCircuits: int, maxReservatio
     resources.MaxReservationsPerASN = maxReservations
     resources.BufferSize = relayBufferSize
     opts = append(opts, libp2p.EnableRelayService(
-        relay.WithResources(resources)
+        relay.WithResources(resources),
     ))
     return opts
 }

--- a/relay.go
+++ b/relay.go
@@ -150,16 +150,16 @@ func BeginRelayDiscovery(h host.Host, dht *dht.IpfsDHT, trustedRelays []string, 
 }
 
 func ConfigureRelayService(opts []libp2p.Option, maxCircuits int, maxReservations int, relayBufferSize int, dataLimit int64, timeLimit time.Duration) []libp2p.Option {
-    resources := relay.DefaultResources()
-    resources.Limit = &relay.RelayLimit{Duration: timeLimit, Data: dataLimit}
-    resources.MaxCircuits = maxCircuits
-    resources.MaxReservations = maxReservations
-    resources.MaxReservationsPerPeer = maxReservations
-    resources.MaxReservationsPerIP = maxReservations
-    resources.MaxReservationsPerASN = maxReservations
-    resources.BufferSize = relayBufferSize
-    opts = append(opts, libp2p.EnableRelayService(
-        relay.WithResources(resources),
-    ))
-    return opts
+	resources := relay.DefaultResources()
+	resources.Limit = &relay.RelayLimit{Duration: timeLimit, Data: dataLimit}
+	resources.MaxCircuits = maxCircuits
+	resources.MaxReservations = maxReservations
+	resources.MaxReservationsPerPeer = maxReservations
+	resources.MaxReservationsPerIP = maxReservations
+	resources.MaxReservationsPerASN = maxReservations
+	resources.BufferSize = relayBufferSize
+	opts = append(opts, libp2p.EnableRelayService(
+		relay.WithResources(resources),
+	))
+	return opts
 }

--- a/relay.go
+++ b/relay.go
@@ -149,7 +149,7 @@ func BeginRelayDiscovery(h host.Host, dht *dht.IpfsDHT, trustedRelays []string, 
 	return cancel
 }
 
-func ConfigureRelayService(opts []libp2p.Option, maxCircuits int, maxReservations int, relayBufferSize int, timeLimit time.Duration, dataLimit int64) []libp2p.Option {
+func ConfigureRelayService(opts []libp2p.Option, maxCircuits int, maxReservations int, relayBufferSize int, dataLimit int64, timeLimit time.Duration) []libp2p.Option {
     resources := relay.DefaultResources()
     resources.Limit = &relay.RelayLimit{Duration: timeLimit, Data: dataLimit}
     resources.MaxCircuits = maxCircuits


### PR DESCRIPTION
This PR adds the following parameters to circuit relays
```python
	relayMaxCircuits := flag.Int("relayMaxCircuits", 16, "maximum number of open relay connections for each peer if -relayService=1")
	relayMaxReservations := flag.Int("relayMaxReservations", 128, "maximum number of reserved relay slots for each peer if -relayService=1")
	relayBufferSize := flag.Int("relayBufferSize", 1<<24, "size (in bytes) of the relayed connection buffers if -relayService=1")
	relayDataLimit := flag.Int64("relayDataLimit", 1<<32, "maximum data bytes relayed (in each direction) before resetting connection if -relayService=1")
	relayTimeLimit := flag.Duration("relayTimeLimit", 30*time.Minute, "maximum duration of a single active relayed connection if -relayService=1")
```