### PR TITLE
Allow transient connections, make sure unary calls use daemon's default ctx

### DIFF
--- a/persistent_stream.go
+++ b/persistent_stream.go
@@ -104,7 +104,7 @@ func (d *Daemon) handlePersistentConnRequest(req pb.PersistentConnectionRequest,
 		}
 
 	case *pb.PersistentConnectionRequest_CallUnary:
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(d.ctx)
 		d.cancelUnary.Store(callID, cancel)
 		defer cancel()
 


### PR DESCRIPTION
When enabling libp2p relays in hivemind, @Vahe1994 noticed the following issue:
- consider a network with one relay (public), one server behind a firewall, and one client (regardless of firewall)
- client attempts to dial a server using the relay as a circuit relay v2
- when the first client uses a relay, it would run normally
- when a second client uses a relay, it would fail
- if there are multiple relays, the first few clients would succeed, and the subsequent clients would fail

Further investigation reveals that this was caused by the following error in p2pd: `transient connection to peer` (details in https://github.com/learning-at-home/hivemind/issues/536 ).

This was caused by the fact that the daemon's main context - the one which allows transient connections - was ignored when opening connections for unary calls. Due to a peculiarity in libp2p's code, this check is ignored when first connecting to a relay - which explains @Vahe1994 's observations. However, all subsequent calls would be forbidden. This pull request fixes the issue by (1) allowing transient connections explicitly and (2) making sure that the context that allows these connections is enabled in unary calls.

WithUseTransient does not enforce that all connections are transient, only that it is **acceptable** to run with these types of connections. Here's the documentation https://github.com/libp2p/go-libp2p/blob/v0.24.1/core/network/context.go#L97-L101

For reference, here's the use of WithUseTransient in libp2p's examples: https://github.com/libp2p/go-libp2p/blob/v0.24.1/examples/relay/main.go#L153
