### PR TITLE
do not run automatic discovery if autoRelay=False

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ type PubSub struct {
 type Relay struct {
 	Enabled  bool
 	Auto     bool
+	Discovery bool
 	HopLimit int
 }
 
@@ -166,6 +167,7 @@ func NewDefaultConfig() Config {
 		Relay: Relay{
 			Enabled:  true,
 			Auto:     false,
+			Discovery:  false,
 			HopLimit: 0,
 		},
 		AutoNat:           false,

--- a/config/config.go
+++ b/config/config.go
@@ -63,10 +63,10 @@ type PubSub struct {
 }
 
 type Relay struct {
-	Enabled  bool
-	Auto     bool
+	Enabled   bool
+	Auto      bool
 	Discovery bool
-	HopLimit int
+	HopLimit  int
 }
 
 type DHT struct {
@@ -165,10 +165,10 @@ func NewDefaultConfig() Config {
 			},
 		},
 		Relay: Relay{
-			Enabled:  true,
-			Auto:     false,
-			Discovery:  false,
-			HopLimit: 0,
+			Enabled:   true,
+			Auto:      false,
+			Discovery: false,
+			HopLimit:  0,
 		},
 		AutoNat:           false,
 		HostAddresses:     make(MaddrArray, 0),


### PR DESCRIPTION
Previously, p2pd would automatically discover relays even if -autoRelay=0. This PR ensures that relay discovery is enabled only if autoRelay is also enabled (like it is described in the help tooltip).